### PR TITLE
Add form toggle test

### DIFF
--- a/__tests__/formToggle.test.js
+++ b/__tests__/formToggle.test.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+
+describe('form toggle', () => {
+  beforeEach(() => {
+    document.documentElement.innerHTML = html.toString();
+    // Reset modules to ensure event listeners are reattached
+    jest.resetModules();
+    require('../script.js');
+  });
+
+  test('sign-up link toggles active class on wrapper', () => {
+    const wrapper = document.querySelector('.wrapper');
+    const signUpLink = document.querySelector('.signUpBtn-link');
+    expect(wrapper.classList.contains('active')).toBe(false);
+    signUpLink.click();
+    expect(wrapper.classList.contains('active')).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "lab1",
+  "version": "1.0.0",
+  "description": "",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.6.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add jest config in `package.json`
- add a test for toggling the form

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f6af860d8832fb708b619d26a368e